### PR TITLE
Fix ControlFlowRanksType test case for torch tracing

### DIFF
--- a/unittests/torch/test_model_eval_cases.py
+++ b/unittests/torch/test_model_eval_cases.py
@@ -98,6 +98,11 @@ class TestModelEvalCases(ExtTestCase):
     def test_run_exporter_yobx_tracing_controlflow_rank(self):
         evaluation(cases="ControlFlowRanks", exporters="yobx-tracing", quiet=False, dynamic=False)
 
+    def test_run_exporter_yobx_tracing_controlflow_rank_type(self):
+        evaluation(
+            cases="ControlFlowRanksType", exporters="yobx-tracing", quiet=False, dynamic=False
+        )
+
     def test_run_exporter_crop_last_dim_tensor_content(self):
         evaluation(
             cases="CropLastDimensionWithTensorContent",

--- a/yobx/torch/_model_eval_cases.py
+++ b/yobx/torch/_model_eval_cases.py
@@ -332,9 +332,9 @@ class ControlFlowRanks(torch.nn.Module):
 
 class ControlFlowRanksType(torch.nn.Module):
     def forward(self, x):
-        if x.ndim == 2 and (x.dtype == torch.float32 or torch.float16):
+        if x.ndim == 2 and (x.dtype == torch.float32 or x.dtype == torch.float16):
             return x.clone()
-        return (x / x.ndim).to(torch.float32s)
+        return (x / x.ndim).to(torch.float32)
 
     _inputs = [(torch.rand(3, 4),), (torch.rand(5, 4),)]
     _dynamic = {"x": {0: DIM("batch")}}


### PR DESCRIPTION
Fixes two bugs in the `ControlFlowRanksType` model eval case and adds a corresponding torch tracing test.

## Changes Made

- **Bug fix**: Corrected `torch.float32s` → `torch.float32` in `ControlFlowRanksType.forward()` (`float32s` does not exist as a torch attribute)
- **Bug fix**: Corrected `x.dtype == torch.float32 or torch.float16` → `x.dtype == torch.float32 or x.dtype == torch.float16` (the original expression was always truthy since `torch.float16` is a non-None object, making the OR a no-op)
- **Test added**: Added `test_run_exporter_yobx_tracing_controlflow_rank_type` in `unittests/torch/test_model_eval_cases.py` to exercise `ControlFlowRanksType` with the `yobx-tracing` exporter

<!-- START COPILOT CODING AGENT TIPS -->
---

🔒 GitHub Advanced Security automatically protects Copilot coding agent pull requests. You can protect all pull requests by enabling Advanced Security for your repositories. [Learn more about Advanced Security.](https://gh.io/cca-advanced-security)