### PR TITLE
check removal

### DIFF
--- a/unittests/torch/test_model_eval_cases.py
+++ b/unittests/torch/test_model_eval_cases.py
@@ -164,9 +164,7 @@ class TestModelEvalCases(ExtTestCase):
         evaluation(cases="InplaceAdd_Mul", exporters="yobx-tracing", quiet=False, dynamic=True)
 
     def test_run_exporter_inplace_clone_add_tracing(self):
-        evaluation(
-            cases="InplaceCloneAdd_", exporters="yobx-tracing", quiet=False, dynamic=True
-        )
+        evaluation(cases="InplaceCloneAdd_", exporters="yobx-tracing", quiet=False, dynamic=True)
 
 
 if __name__ == "__main__":

--- a/unittests/torch/test_tracing.py
+++ b/unittests/torch/test_tracing.py
@@ -362,9 +362,9 @@ class TestTracing(ExtTestCase):
         x = torch.ones((4, 4))
         expected = model(x)
         graph = CustomTracer().trace(model)
-        self.assertIn("add_]", str(graph))
+        self.assertNotIn("add_]", str(graph))
         mod = torch.fx.GraphModule(model, graph)
-        self.assertIn("add_]", str(mod.graph))
+        self.assertNotIn("add_]", str(mod.graph))
         got = mod(x)
         self.assertEqualArray(expected, got)
 

--- a/yobx/torch/interpreter/_aten_methods.py
+++ b/yobx/torch/interpreter/_aten_methods.py
@@ -43,7 +43,7 @@ def aten_meth_add_(
     name: str = "meth_add_",
 ) -> T:
     "``add_``"
-    raise RuntimeError("This should not happend.")
+    raise RuntimeError(f"This should not happend.\n{g.get_debug_msg()}")
 
 
 def aten_meth_clamp_max(

--- a/yobx/torch/interpreter/_aten_methods.py
+++ b/yobx/torch/interpreter/_aten_methods.py
@@ -33,19 +33,6 @@ def aten_meth_bool(g: GraphBuilder, sts: Optional[Dict[str, Any]], outputs: List
     return aten_meth_to(g, sts, outputs, x, dtype=torch.bool)
 
 
-def aten_meth_add_(
-    g: GraphBuilder,
-    sts: Optional[Dict[str, Any]],
-    outputs: List[str],
-    x: T,
-    y: T,
-    alpha: Optional[Any] = None,
-    name: str = "meth_add_",
-) -> T:
-    "``add_``"
-    raise RuntimeError(f"This should not happend.\n{g.get_debug_msg()}")
-
-
 def aten_meth_clamp_max(
     g: GraphBuilder,
     sts: Optional[Dict[str, Any]],

--- a/yobx/torch/interpreter/_aten_methods.py
+++ b/yobx/torch/interpreter/_aten_methods.py
@@ -12,7 +12,7 @@ from ...xshape.shape_type_compute import (
 )
 from ._aten_functions import (
     torch_dtype_to_onnx_dtype,
-    aten_add__Tensor,
+    # aten_add__Tensor,
     aten_clamp_max,
     aten_clamp_min,
     aten_cos,
@@ -43,7 +43,7 @@ def aten_meth_add_(
     name: str = "meth_add_",
 ) -> T:
     "``add_``"
-    return aten_add__Tensor(g, sts, outputs, x, y, alpha=alpha, name=name)
+    raise RuntimeError("This should not happend.")
 
 
 def aten_meth_clamp_max(

--- a/yobx/torch/tracing.py
+++ b/yobx/torch/tracing.py
@@ -1813,6 +1813,57 @@ class CustomTracer(torch.fx.Tracer):
         return n_inplace
 
     @classmethod
+    def _replace_inplace_call_methods(cls, graph: torch.fx.Graph, verbose: int = 0) -> int:
+        """
+        Replaces ``call_method`` nodes with inplace targets (e.g. ``add_``, ``mul_``,
+        ``sub_``, ``div_``) with their non-inplace ``call_function`` equivalents.
+
+        For each such node, the first argument is the tensor modified in-place.
+        After conversion, all uses of that first argument that appear *after*
+        the current node are replaced with the new non-inplace result, preserving
+        the original in-place semantics.
+
+        :param graph: graph to modify
+        :param verbose: verbosity level
+        :return: number of nodes replaced
+        """
+        _method_to_aten = {
+            "add_": torch.ops.aten.add.Tensor,
+            "mul_": torch.ops.aten.mul.Tensor,
+            "sub_": torch.ops.aten.sub.Tensor,
+            "div_": torch.ops.aten.div.Tensor,
+        }
+        n = 0
+        # Build a position map for O(1) position lookups inside the loop.
+        position_map = {node: pos for pos, node in enumerate(graph.nodes)}
+        existing_nodes = list(enumerate(graph.nodes))
+        for pos, node in existing_nodes:
+            if (
+                node.op != "call_method"
+                or not isinstance(node.target, str)
+                or node.target not in _method_to_aten
+            ):
+                continue
+            old_first_arg = (
+                node.args[0] if node.args and isinstance(node.args[0], torch.fx.Node) else None
+            )
+            old_target = node.target
+            node.op = "call_function"
+            node.target = _method_to_aten[old_target]
+            n += 1
+            if old_first_arg is not None and old_first_arg.users:
+                old_first_arg.replace_all_uses_with(
+                    node,
+                    delete_user_cb=lambda user, p=pos: position_map.get(user, -1) > p,
+                )
+            if verbose > 1:
+                print(
+                    f"[CustomTracer._replace_inplace_call_methods] replaced "
+                    f"call_method {old_target!r} -> aten at {node.name!r}"
+                )
+        return n
+
+    @classmethod
     def remove_inplace(
         cls,
         graph: torch.fx.Graph,
@@ -1852,6 +1903,9 @@ class CustomTracer(torch.fx.Tracer):
                     if inpl < 0:
                         return inpl
                     n_inplace_submobules += inpl
+
+        # Convert call_method inplace nodes (add_, mul_, etc.) to call_function equivalents.
+        cls._replace_inplace_call_methods(graph, verbose=verbose)
 
         # Remove obvious unused nodes.
         rem = []

--- a/yobx/torch/tracing.py
+++ b/yobx/torch/tracing.py
@@ -1851,11 +1851,16 @@ class CustomTracer(torch.fx.Tracer):
             node.op = "call_function"
             node.target = _method_to_aten[old_target]
             n += 1
-            if old_first_arg is not None and old_first_arg.users:
-                old_first_arg.replace_all_uses_with(
-                    node,
-                    delete_user_cb=lambda user, p=pos: position_map.get(user, -1) > p,
-                )
+            if old_first_arg is not None:
+                # Only replace uses of old_first_arg that appear *after* the inplace node.
+                # Users at or before pos (including node itself) are left untouched so that
+                # they continue to reference the pre-modification value, which preserves
+                # correct in-place semantics.
+                if any(position_map.get(user, -1) > pos for user in old_first_arg.users):
+                    old_first_arg.replace_all_uses_with(
+                        node,
+                        delete_user_cb=lambda user, p=pos: position_map.get(user, -1) > p,
+                    )
             if verbose > 1:
                 print(
                     f"[CustomTracer._replace_inplace_call_methods] replaced "


### PR DESCRIPTION
- [x] Analyze the issue: `call_method[target=add_]` with `num_users=1` not handled by CustomTracer
- [x] Add `_replace_inplace_call_methods` to convert `call_method` inplace nodes to `call_function` in `CustomTracer.remove_inplace`
- [x] Update `test_tracing_inplace_add_` to expect `add_]` to be removed from graph after `remove_inplace=True`
- [x] Guard `replace_all_uses_with`: explicitly check that `node.args[0]` has users after the current position before replacing; preserves pre-modification references for earlier uses

<!-- START COPILOT CODING AGENT TIPS -->
---

⌨️ Start Copilot coding agent tasks without leaving your editor — available in [VS Code](https://gh.io/cca-vs-code-docs), [Visual Studio](https://gh.io/cca-visual-studio-docs), [JetBrains IDEs](https://gh.io/cca-jetbrains-docs) and [Eclipse](https://gh.io/cca-eclipse-docs).
