### PR TITLE
Apply full inplace-op postprocessing in NEW_TRACING export path

### DIFF
--- a/unittests/torch/test_model_eval_cases.py
+++ b/unittests/torch/test_model_eval_cases.py
@@ -249,6 +249,9 @@ class TestModelEvalCases(ExtTestCase):
     def test_run_exporter_aten_as_strided_new_tracing(self):
         evaluation(cases="AtenAsStrided", exporters="yobx-new-tracing", quiet=False, dynamic=True)
 
+    def test_run_exporter_aten_inplace_add_new_tracing(self):
+        evaluation(cases="InplaceAdd", exporters="yobx-new-tracing", quiet=False, dynamic=True)
+
     def test_control_flow_numel_zero_1(self):
         evaluation(
             cases="ControlFlowNumelZero1", exporters="yobx-tracing", quiet=False, dynamic=True

--- a/unittests/torch/test_tracing.py
+++ b/unittests/torch/test_tracing.py
@@ -310,6 +310,52 @@ class TestCustomTracer(ExtTestCase):
         result = CustomTracer.remove_inplace(graph)
         self.assertEqual(result, 0)
 
+    def test_replace_inplace_aten_functions_no_op(self):
+        # Graph with only a non-inplace add — nothing should be replaced.
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        y = graph.placeholder("y")
+        add_node = graph.call_function(torch.ops.aten.add.Tensor, args=(x, y))
+        graph.output(add_node)
+
+        result = CustomTracer._replace_inplace_aten_functions(graph)
+        self.assertEqual(result, 0)
+        # Target unchanged
+        add_nodes = [n for n in graph.nodes if n.op == "call_function"]
+        self.assertEqual(len(add_nodes), 1)
+        self.assertEqual(add_nodes[0].target, torch.ops.aten.add.Tensor)
+
+    def test_replace_inplace_aten_functions_tensor(self):
+        # Graph with an inplace aten.add_.Tensor node — it should be rewritten
+        # to aten.add.Tensor and its users preserved.
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        y = graph.placeholder("y")
+        add_node = graph.call_function(torch.ops.aten.add_.Tensor, args=(x, y))
+        graph.output(add_node)
+
+        result = CustomTracer._replace_inplace_aten_functions(graph)
+        self.assertEqual(result, 1)
+        # Target must be the non-inplace variant now
+        fn_nodes = [n for n in graph.nodes if n.op == "call_function"]
+        self.assertEqual(len(fn_nodes), 1)
+        self.assertEqual(fn_nodes[0].target, torch.ops.aten.add.Tensor)
+        # Output still references the (now non-inplace) node
+        output_node = next(n for n in graph.nodes if n.op == "output")
+        self.assertIs(output_node.args[0], fn_nodes[0])
+
+    def test_replace_inplace_aten_functions_scalar(self):
+        # Graph with aten.add_.Scalar — should become aten.add.Scalar.
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        add_node = graph.call_function(torch.ops.aten.add_.Scalar, args=(x, 2))
+        graph.output(add_node)
+
+        result = CustomTracer._replace_inplace_aten_functions(graph)
+        self.assertEqual(result, 1)
+        fn_nodes = [n for n in graph.nodes if n.op == "call_function"]
+        self.assertEqual(fn_nodes[0].target, torch.ops.aten.add.Scalar)
+
     def test_remove_unnecessary_slices_no_slice(self):
         class Model(torch.nn.Module):
             def forward(self, x, y):

--- a/yobx/torch/export_options.py
+++ b/yobx/torch/export_options.py
@@ -566,6 +566,10 @@ class ExportOptions:
                 module_leaves=self.tracing_module_leaves,
             )
 
+            from .tracing import CustomTracer
+
+            CustomTracer._replace_inplace_aten_functions(graph, verbose=verbose)
+
             if self.save_ep:
                 save_ep = self.save_ep[0] if isinstance(self.save_ep, tuple) else self.save_ep
                 with open(f"{save_ep}.new_tracing", "w") as f:

--- a/yobx/torch/export_options.py
+++ b/yobx/torch/export_options.py
@@ -568,7 +568,7 @@ class ExportOptions:
 
             from .tracing import CustomTracer
 
-            CustomTracer._replace_inplace_aten_functions(graph, verbose=verbose)
+            CustomTracer.remove_inplace(graph, verbose=verbose)
 
             if self.save_ep:
                 save_ep = self.save_ep[0] if isinstance(self.save_ep, tuple) else self.save_ep

--- a/yobx/torch/interpreter/_aten_functions.py
+++ b/yobx/torch/interpreter/_aten_functions.py
@@ -9982,11 +9982,7 @@ def aten_prod_dim_int(
 
 
 def aten_ravel(
-    g: GraphBuilder,
-    sts: Optional[Dict[str, Any]],
-    outputs: List[str],
-    x: T,
-    name: str = "ravel",
+    g: GraphBuilder, sts: Optional[Dict[str, Any]], outputs: List[str], x: T, name: str = "ravel"
 ) -> T:
     """Reshapes the input tensor to 1D."""
     return aten_flatten_using_ints(g, sts, outputs, x, start_dim=0, end_dim=-1, name=name)

--- a/yobx/torch/interpreter/interpreter.py
+++ b/yobx/torch/interpreter/interpreter.py
@@ -1903,7 +1903,9 @@ class DynamoInterpreter:
             # if an int, it cannot be modified inplace
             or (
                 "val" in node.meta
-                and isinstance(node.meta["val"], (int, self.torch.SymInt, self.TracingInt))
+                and isinstance(
+                    node.meta["val"], (int, self.torch.SymInt, self.builder.TracingInt)
+                )
             )
         ), (
             f"This is probably one inplace function node={node!r}, "

--- a/yobx/torch/tracing.py
+++ b/yobx/torch/tracing.py
@@ -2556,6 +2556,51 @@ class CustomTracer(torch.fx.Tracer):
         return n
 
     @classmethod
+    def _replace_inplace_aten_functions(cls, graph: torch.fx.Graph, verbose: int = 0) -> int:
+        """
+        Replaces ``call_function`` nodes whose target is an inplace ATen binary
+        op (e.g. ``aten.add_.Tensor``, ``aten.mul_.Scalar``) with their
+        non-inplace equivalents (e.g. ``aten.add.Tensor``,
+        ``aten.mul.Scalar``).
+
+        This is the counterpart of :meth:`_replace_inplace_call_methods` for
+        graphs produced by :class:`~yobx.torch.new_tracing.GraphTracer` where
+        inplace dispatch operations are already recorded as ``call_function``
+        ATen nodes with the trailing ``_`` in the overload name.  Because
+        :class:`~yobx.torch.new_tracing.GraphTracer` correctly reassigns
+        Python-level references on each inplace call, downstream users of the
+        result already point to the inplace node — no user-rerouting is needed;
+        only the target needs to be rewritten.
+
+        :param graph: graph to modify
+        :param verbose: verbosity level
+        :return: number of nodes replaced
+        """
+        _aten_inplace_to_non_inplace = {
+            torch.ops.aten.add_.Tensor: torch.ops.aten.add.Tensor,
+            torch.ops.aten.add_.Scalar: torch.ops.aten.add.Scalar,
+            torch.ops.aten.mul_.Tensor: torch.ops.aten.mul.Tensor,
+            torch.ops.aten.mul_.Scalar: torch.ops.aten.mul.Scalar,
+            torch.ops.aten.sub_.Tensor: torch.ops.aten.sub.Tensor,
+            torch.ops.aten.sub_.Scalar: torch.ops.aten.sub.Scalar,
+            torch.ops.aten.div_.Tensor: torch.ops.aten.div.Tensor,
+            torch.ops.aten.div_.Scalar: torch.ops.aten.div.Scalar,
+        }
+        n = 0
+        for node in graph.nodes:
+            if node.op != "call_function" or node.target not in _aten_inplace_to_non_inplace:
+                continue
+            old_target = node.target
+            node.target = _aten_inplace_to_non_inplace[old_target]
+            n += 1
+            if verbose > 1:
+                print(
+                    f"[CustomTracer._replace_inplace_aten_functions] replaced "
+                    f"aten inplace {old_target!r} -> non-inplace at {node.name!r}"
+                )
+        return n
+
+    @classmethod
     def remove_inplace(
         cls,
         graph: torch.fx.Graph,
@@ -2596,6 +2641,8 @@ class CustomTracer(torch.fx.Tracer):
                         return inpl
                     n_inplace_submobules += inpl
 
+        # Convert call_function inplace ATen nodes (aten.add_.Tensor, etc.) to non-inplace.
+        cls._replace_inplace_aten_functions(graph, verbose=verbose)
         # Convert call_method inplace nodes (add_, mul_, etc.) to call_function equivalents.
         cls._replace_inplace_call_methods(graph, verbose=verbose)
 


### PR DESCRIPTION
`GraphTracer` (NEW_TRACING) emits inplace ATen ops (`aten.add_.Tensor`, etc.) as `call_function` nodes, which the classic `_replace_inplace_call_methods` (handles only `call_method` nodes) left untouched, breaking models like `InplaceAdd`.

## Changes

- **`yobx/torch/tracing.py`** — New `CustomTracer._replace_inplace_aten_functions` classmethod: rewrites `call_function` inplace ATen binary ops (`add_`, `mul_`, `sub_`, `div_` — both `.Tensor` and `.Scalar` overloads) to their non-inplace equivalents. Also wired into `remove_inplace()` so both tracing paths benefit.

- **`yobx/torch/export_options.py`** — NEW_TRACING export path now calls `CustomTracer.remove_inplace(graph)` (instead of only `_replace_inplace_aten_functions`), applying the full postprocessing pipeline consistently with the classic TRACING path.

- **`unittests/torch/test_tracing.py`** — Unit tests for `_replace_inplace_aten_functions`: no-op (non-inplace), `.Tensor` overload, `.Scalar` overload.

```python
class InplaceAdd(torch.nn.Module):
    def forward(self, x):
        x += self.bias  # GraphTracer emits aten.add_.Tensor
        return x

# After remove_inplace():
# %add = call_function[aten.add.Tensor](%x, %bias)  ← inplace gone
# output(%add)
```