### PR TITLE
[yobx/torch] fix validate_model atol/rtol support

### DIFF
--- a/unittests/torch/test_validate.py
+++ b/unittests/torch/test_validate.py
@@ -46,13 +46,14 @@ class TestValidateSummaryFields(ExtTestCase):
         self.assertEqual(d["top_op_types"], "MatMul:5,Add:3")
 
     def test_discrepancy_stats_fields_exist(self):
-        """ValidateSummary exposes discrepancies_max_abs, atol, ratio_001, and ratio_01 fields."""
+        """ValidateSummary exposes discrepancies_max_abs, atol, rtol, ratio_001, and ratio_01 fields."""  # noqa: E501
         from dataclasses import fields
         from yobx.torch.validate import ValidateSummary
 
         names = {f.name for f in fields(ValidateSummary)}
         self.assertIn("discrepancies_max_abs", names)
         self.assertIn("discrepancies_atol", names)
+        self.assertIn("discrepancies_rtol", names)
         self.assertIn("discrepancies_ratio_001", names)
         self.assertIn("discrepancies_ratio_01", names)
 
@@ -63,11 +64,13 @@ class TestValidateSummaryFields(ExtTestCase):
         s = ValidateSummary(model_id="m", prompt="p")
         s.discrepancies_max_abs = 0.005
         s.discrepancies_atol = 1e-4
+        s.discrepancies_rtol = 0.1
         s.discrepancies_ratio_001 = 0.02
         s.discrepancies_ratio_01 = 0.0
         d = dict(s.items())
         self.assertAlmostEqual(d["discrepancies_max_abs"], 0.005)
         self.assertAlmostEqual(d["discrepancies_atol"], 1e-4)
+        self.assertAlmostEqual(d["discrepancies_rtol"], 0.1)
         self.assertAlmostEqual(d["discrepancies_ratio_001"], 0.02)
         self.assertAlmostEqual(d["discrepancies_ratio_01"], 0.0)
 
@@ -419,6 +422,39 @@ class TestValidateModel(ExtTestCase):
         # Discrepancies from check_discrepancies should be stored in the report.
         if data.discrepancies:
             self.assertEqual(len(data.artifact.report.discrepancies), len(data.discrepancies))
+
+    def test_validate_model_discrepancies_table_has_atol_rtol(self):
+        """Each row in the discrepancies table produced by validate_model has atol and rtol columns."""  # noqa: E501
+        import torch
+        from yobx.torch.validate import validate_model
+
+        custom_atol = 1e-3
+        custom_rtol = 0.05
+        tokenized = {
+            "input_ids": torch.randint(0, 1000, (1, 5), dtype=torch.int64),
+            "attention_mask": torch.ones(1, 5, dtype=torch.int64),
+        }
+        summary, data = validate_model(
+            "arnir0/Tiny-LLM",
+            tokenized_inputs=tokenized,
+            random_weights=True,
+            max_new_tokens=3,
+            do_run=True,
+            quiet=True,
+            verbose=0,
+            atol=custom_atol,
+            rtol=custom_rtol,
+        )
+        self.assertIsNotNone(data.discrepancies)
+        self.assertGreater(len(data.discrepancies), 0)
+        for row in data.discrepancies:
+            self.assertIn("atol", row, msg="atol column missing from discrepancies table row")
+            self.assertIn("rtol", row, msg="rtol column missing from discrepancies table row")
+            self.assertAlmostEqual(row["atol"], custom_atol)
+            self.assertAlmostEqual(row["rtol"], custom_rtol)
+        # The summary should also record the tolerances used.
+        self.assertAlmostEqual(summary.discrepancies_atol, custom_atol)
+        self.assertAlmostEqual(summary.discrepancies_rtol, custom_rtol)
 
     @skipif_ci_windows("xlsx file locked by another process on Windows")
     def test_validate_model_artifact_xlsx_has_discrepancies_sheet(self):

--- a/yobx/helpers/onnx_helper.py
+++ b/yobx/helpers/onnx_helper.py
@@ -867,7 +867,7 @@ def _validate_function(g: onnx.FunctionProto, verbose: int = 0, watch: Optional[
 
 def onnx_find(
     onx: Union[str, onnx.ModelProto], verbose: int = 0, watch: Optional[Set[str]] = None
-) -> List[Union[onnx.NodeProto, onnx.TensorProto]]:
+) -> List[Union[onnx.NodeProto, onnx.TensorProto, onnx.ValueInfoProto]]:
     """
     Looks for node producing or consuming some results.
 

--- a/yobx/torch/input_observer.py
+++ b/yobx/torch/input_observer.py
@@ -1488,6 +1488,8 @@ class InputObserver:
                     n_inputs=len(input_names),
                     n_none=n_none,
                     n_empty=n_empty,
+                    atol=atol,
+                    rtol=rtol,
                 )
             )
             if include_io:

--- a/yobx/torch/interpreter/_aten_getitem.py
+++ b/yobx/torch/interpreter/_aten_getitem.py
@@ -6,7 +6,7 @@ a :class:`~yobx.xbuilder.GraphBuilder` as their first argument so they can
 be used independently of the interpreter.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 from onnx import TensorProto
@@ -110,9 +110,9 @@ def _getitem_slice(
     if g.has_shape(input_name):
         shape_value = g.get_shape(input_name)
 
-    starts = []
-    ends = []
-    steps = []
+    starts: List[Union[int, str]] = []
+    ends: List[Union[int, str]] = []
+    steps: List[int] = []
     shape_name = None
     end_name = None
     concat = False
@@ -184,7 +184,7 @@ def _getitem_slice(
 
     # if concat: one end is coming from a shape
     if concat:
-        iends = []
+        iends: List[Any] = []
         for i in ends:
             if isinstance(i, str):
                 if g.get_rank(i) == 0:
@@ -222,7 +222,7 @@ def _getitem_slice(
             source="_getitem_slice.2",
         )
     else:
-        istarts = []
+        istarts: List[Any] = []
         for i in starts:
             si = i.name if hasattr(i, "name") else i
             if isinstance(si, str):
@@ -233,7 +233,7 @@ def _getitem_slice(
                 else:
                     assert (
                         g.get_rank(si) == 1
-                    ), f"Unexpected rank={g.get_rank(i)} for {si!r}{g.get_debug_msg()}"
+                    ), f"Unexpected rank={g.get_rank(si)} for {si!r}{g.get_debug_msg()}"
                     istarts.append(si)
             else:
                 assert isinstance(si, int), f"Unexpected value for end={si!r}{g.get_debug_msg()}"

--- a/yobx/torch/validate.py
+++ b/yobx/torch/validate.py
@@ -1303,7 +1303,14 @@ def validate_model(
         assert collected_data.filename, "No filename, this is needed to check for discrepancies."
         assert os.path.exists(collected_data.filename), f"{collected_data.filename!r} is missing"
         _check_discrepancies(
-            observer, collected_data.filename, verbose, quiet, summary, collected_data
+            observer,
+            collected_data.filename,
+            verbose,
+            quiet,
+            summary,
+            collected_data,
+            atol=atol,
+            rtol=rtol,
         )
 
     # --------------------------------- update xlsx report with discrepancies (yobx exporter only)

--- a/yobx/torch/validate.py
+++ b/yobx/torch/validate.py
@@ -79,7 +79,6 @@ class ValidateSummary:
     discrepancies_rtol: Optional[float] = None
     discrepancies_ratio_001: Optional[float] = None
     discrepancies_ratio_01: Optional[float] = None
-    discrepancies_rtol: Optional[float] = None
     error_discrepancies: Optional[str] = None
 
     def __init__(

--- a/yobx/torch/validate.py
+++ b/yobx/torch/validate.py
@@ -887,20 +887,21 @@ def _check_discrepancies(
     quiet: bool,
     summary: "ValidateSummary",
     collected_data: "ValidateData",
+    atol: float = 1e-4,
+    rtol: float = 0.1,
 ):
     """Run ONNX Runtime on every captured input set and compare against PyTorch outputs."""
     if verbose:
         print("[validate_model] checking discrepancies ...")
-    atol = 1e-4
     if quiet:
         try:
-            disc_data = observer.check_discrepancies(filename, atol=atol)
+            disc_data = observer.check_discrepancies(filename, atol=atol, rtol=rtol)
         except Exception as exc:
             summary.discrepancies = "FAILED"
             summary.error_discrepancies = str(exc)
             return
     else:
-        disc_data = observer.check_discrepancies(filename, atol=atol)
+        disc_data = observer.check_discrepancies(filename, atol=atol, rtol=rtol)
     collected_data.discrepancies = disc_data
     n_ok = sum(1 for row in disc_data if row.get("SUCCESS", False))
     n_total = len(disc_data)
@@ -908,6 +909,7 @@ def _check_discrepancies(
     summary.discrepancies_total = n_total
     summary.discrepancies = "OK" if n_ok == n_total else "FAILED"
     summary.discrepancies_atol = atol
+    summary.discrepancies_rtol = rtol
     # Aggregate per-element stats across all examples that ran without error.
     numeric_rows = [row for row in disc_data if "abs" in row]
     if numeric_rows:
@@ -957,6 +959,8 @@ def validate_model(
     tokenized_inputs: Optional[Dict[str, Any]] = None,
     config_overrides: Optional[Dict[str, Any]] = None,
     random_weights: bool = False,
+    atol: float = 1e-4,
+    rtol: float = 0.1,
 ) -> Tuple["ValidateSummary", "ValidateData"]:
     """
     Validates an ONNX export for any HuggingFace ``model_id`` by capturing real
@@ -1023,6 +1027,8 @@ def validate_model(
         (possibly modified) config with random weights instead of downloading
         the pretrained weights.  This avoids any network access for the model
         itself, which is useful for fast unit-testing or CI validation.
+    :param atol: absolute tolerance
+    :param rtol: relative tolerance
     :return: A 2-tuple ``(summary, data)`` where *summary* is a
         :class:`ValidateSummary` instance with status flags and error messages,
         and *data* is a :class:`ValidateData` instance that collects all
@@ -1106,7 +1112,14 @@ def validate_model(
                 collected_data.filename
             ), f"{collected_data.filename!r} is missing"
             _check_discrepancies(
-                observer, collected_data.filename, verbose, quiet, summary, collected_data
+                observer,
+                collected_data.filename,
+                verbose,
+                quiet,
+                summary,
+                collected_data,
+                atol=atol,
+                rtol=rtol,
             )
 
         from ..container import ExportArtifact

--- a/yobx/torch/validate.py
+++ b/yobx/torch/validate.py
@@ -49,6 +49,7 @@ class ValidateSummary:
         discrepancies: ``"OK"`` or ``"FAILED"`` for the overall discrepancy check.
         discrepancies_max_abs: Maximum absolute discrepancy across all input sets.
         discrepancies_atol: Absolute tolerance threshold used to determine success.
+        discrepancies_rtol: Relative tolerance threshold used to determine success.
         discrepancies_ratio_001: Fraction of output elements with absolute difference > 0.01,
             aggregated across all input sets.
         discrepancies_ratio_01: Fraction of output elements with absolute difference > 0.1,
@@ -75,6 +76,7 @@ class ValidateSummary:
     discrepancies: Optional[str] = None
     discrepancies_max_abs: Optional[float] = None
     discrepancies_atol: Optional[float] = None
+    discrepancies_rtol: Optional[float] = None
     discrepancies_ratio_001: Optional[float] = None
     discrepancies_ratio_01: Optional[float] = None
     error_discrepancies: Optional[str] = None
@@ -100,6 +102,7 @@ class ValidateSummary:
         discrepancies: Optional[str] = None,
         discrepancies_max_abs: Optional[float] = None,
         discrepancies_atol: Optional[float] = None,
+        discrepancies_rtol: Optional[float] = None,
         discrepancies_ratio_001: Optional[float] = None,
         discrepancies_ratio_01: Optional[float] = None,
         error_discrepancies: Optional[str] = None,
@@ -123,6 +126,7 @@ class ValidateSummary:
         self.discrepancies = discrepancies
         self.discrepancies_max_abs = discrepancies_max_abs
         self.discrepancies_atol = discrepancies_atol
+        self.discrepancies_rtol = discrepancies_rtol
         self.discrepancies_ratio_001 = discrepancies_ratio_001
         self.discrepancies_ratio_01 = discrepancies_ratio_01
         self.error_discrepancies = error_discrepancies

--- a/yobx/torch/validate.py
+++ b/yobx/torch/validate.py
@@ -77,6 +77,7 @@ class ValidateSummary:
     discrepancies_atol: Optional[float] = None
     discrepancies_ratio_001: Optional[float] = None
     discrepancies_ratio_01: Optional[float] = None
+    discrepancies_rtol: Optional[float] = None
     error_discrepancies: Optional[str] = None
 
     def __init__(

--- a/yobx/xbuilder/graph_builder.py
+++ b/yobx/xbuilder/graph_builder.py
@@ -6570,7 +6570,7 @@ class GraphBuilder(
     def _improve_constraints(self):
         """Adds more correspondences deduced from self.constraints_."""
 
-        update = {}
+        update: Dict[str, Set[Union[str, int]]] = {}
         it = 0
         while (update or it == 0) and it < 10:
             it += 1
@@ -8068,8 +8068,9 @@ class GraphBuilder(
             # trouble, let's assume one move is ok.
             mini = max((first_at.get(i, -1), i) for i in node.input if i)
             pos, name = mini
-            assert (
-                name in self.nodes[pos].output
+            node_at_pos = self.nodes[pos]
+            assert node_at_pos is not None and (
+                name in node_at_pos.output
             ), f"Name {name!r} should be at node position {pos}"
             new_position = self._move_node_position(pos)
             if not new_position:
@@ -8411,12 +8412,12 @@ class GraphBuilder(
             )
             set_shape_type_custom(self, node)  # type: ignore[arg-type]
 
-    def infer_shapes(self) -> Dict[str, Tuple[DYNAMIC_SHAPE, DYNAMIC_SHAPE]]:
+    def infer_shapes(self) -> Dict[str, Tuple[Optional[DYNAMIC_SHAPE], Optional[DYNAMIC_SHAPE]]]:
         """Runs custom shape inference. Returns the updates."""
         begin = time.perf_counter()
         if self.verbose > 1:
             print("[GraphBuilder.infer_shapes]")
-        res: Dict[str, Tuple[DYNAMIC_SHAPE, DYNAMIC_SHAPE]] = {}
+        res: Dict[str, Tuple[Optional[DYNAMIC_SHAPE], Optional[DYNAMIC_SHAPE]]] = {}
         for node in self.nodes:
             if not node:
                 continue

--- a/yobx/xbuilder/graph_builder.py
+++ b/yobx/xbuilder/graph_builder.py
@@ -6608,12 +6608,13 @@ class GraphBuilder(
                         f"{k=}, {k2=}, {vv=}, {vv2=}, {n1=}, {n2=}, {v=}, "
                         f"{self.constraints_=}{self.get_debug_msg()}"
                     )
-                    eq = {k, k2, vv, vv2}
+                    eq: Set[Union[str, int]] = {k, k2, vv, vv2}
                     for e in eq:
-                        if e not in update:
-                            update[e] = eq
+                        es = cast(str, e)
+                        if es not in update:
+                            update[es] = eq
                         else:
-                            update[e] |= eq
+                            update[es] |= eq
 
             for k, v in update.items():
                 if self._debug_dyn_dim and self._debug_dyn_dim & {k}:


### PR DESCRIPTION
Adds `atol` and `rtol` parameters to `validate_model` and propagates them through `_check_discrepancies` to `InputObserver.check_discrepancies`.

## Changes Made

- **`validate_model`**: Added `atol` (default `1e-4`) and `rtol` (default `0.1`) parameters, forwarded to `_check_discrepancies`.
- **`_check_discrepancies`**: Accepts `atol`/`rtol` and passes them to `observer.check_discrepancies`.
- **`ValidateSummary`**: Added `discrepancies_rtol` as a proper declared dataclass field (alongside the existing `discrepancies_atol`), recorded after each discrepancy check.
- **Tests**: Added `test_validate_model_discrepancies_table_has_atol_rtol` — runs `validate_model` with custom `atol`/`rtol` values and asserts every row in `data.discrepancies` contains `"atol"` and `"rtol"` columns with the correct values, and that `summary.discrepancies_atol`/`summary.discrepancies_rtol` match. Extended existing field-existence and `items()` tests to cover `discrepancies_rtol`.